### PR TITLE
Allow opt-in fal.ai MCP while preserving Higgsfield defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,17 @@ The workflow starts with your business and brand, establishes a visual direction
 ## What you need
 
 - GPT-6 Astra in a coding environment that can create and run a website.
-- **Higgsfield MCP connected, with image and video generation tools available.** These prompts use Higgsfield MCP to generate brand assets, images and videos, including the media used in the scroll-scrubbing animation.
-- Access to the generation models required by your chosen workflow. Asset generation may use paid credits in your Higgsfield account.
+- **A connected media provider with the required image and video tools available.** Higgsfield MCP is the default; fal.ai MCP is an opt-in alternative described below. The selected provider generates brand assets, images and videos, including scroll-scrubbing media.
+- Access to the generation models required by your chosen workflow. Asset generation may use paid credits in your selected provider account.
 - A hosting option when you are ready to publish. The prompt follows the workflow available in your environment.
 
 **[Get started with Higgsfield — my referral link](https://higgsfield.ai/s/gpt-6-astra-yt-bartslodyczka-ZqPdIF)**
 
-The prompts provide instructions; they do not install or connect Higgsfield MCP for you.
+The prompts provide instructions; they do not install or connect generation tools for you.
+
+### Optional provider: fal.ai MCP
+
+Higgsfield MCP remains the default. If you explicitly request fal.ai MCP, the prompts can use it after verifying that the required image and video tools are callable. Model availability and controls vary: inspect the live schema for portrait output, reference images, and matching first/last frames before generation. Mobile refinement continues with the selected desktop provider; it does not silently switch providers.
 
 ## 1. Build your website
 

--- a/prompts/01-desktop-build.md
+++ b/prompts/01-desktop-build.md
@@ -2,7 +2,7 @@
 
 Act as a designer, creative director and website developer. Build the actual website, including its visual assets and working scroll animation. The experience should tell the business's story through motion, typography and content that feel composed together.
 
-Use Higgsfield MCP for generated images and video. Stay in the current conversation and project. Do not silently substitute browser control, another generation provider, or another conversation. A skill supplies instructions, not tool access: verify the required image/video tools are callable before promising generation. If they are missing, state the exact capability gap once, ask for the smallest necessary action, and continue independent work. Do not repeatedly recommend reinstalling an already connected plugin.
+Use Higgsfield MCP for generated images and video by default. If the user explicitly requests fal.ai MCP, use it instead only after verifying that its required image/video tools are callable. Keep the selected provider consistent across the workflow unless the user authorizes a change. Stay in the current conversation and project. Do not silently substitute browser control, another generation provider, or another conversation. A skill supplies instructions, not tool access: verify the required image/video tools are callable before promising generation. If they are missing, state the exact capability gap once, ask for the smallest necessary action, and continue independent work. Do not repeatedly recommend reinstalling an already connected plugin.
 
 ## 1. Establish the brief with minimal friction
 
@@ -26,7 +26,7 @@ Preserve real supplied facts. Do not fabricate testimonials, customers, awards, 
 
 If a logo or official assets are supplied, preserve them. Distinguish inspiration from material the user owns or has declared authoritative. Do not redraw an existing logo to make it fit a new aesthetic.
 
-If identity is missing, develop a small set of appropriate directions. Use Higgsfield MCP to generate logo concepts when a logo is needed. Select the strongest in autonomous mode; otherwise show a compact selection. Prefer an editable vector master when the available model supports it. A raster export is not an SVG master.
+If identity is missing, develop a small set of appropriate directions. Use the selected provider (Higgsfield MCP by default, or fal.ai MCP when explicitly requested) to generate logo concepts when a logo is needed. Select the strongest in autonomous mode; otherwise show a compact selection. Prefer an editable vector master when the available model supports it. A raster export is not an SVG master.
 
 Inspect supplied reference websites before describing their design. Extract useful characteristics such as typography, spacing, contrast, composition, materials, component treatment and motion. References such as component libraries can inform implementation; do not copy proprietary branding or distinctive artwork wholesale.
 

--- a/prompts/02-mobile-refinement.md
+++ b/prompts/02-mobile-refinement.md
@@ -32,6 +32,8 @@ During the main animation, allow the imagery to occupy the screen without unnece
 
 3. DEDICATED PORTRAIT ANIMATION
 
+Continue with the provider selected for the desktop build: Higgsfield MCP by default, or fal.ai MCP when explicitly requested. Verify its portrait-generation tools and live model schema before submitting. If the required tools are unavailable, explain the gap and continue independent layout work; do not silently switch providers.
+
 For a cinematic image-sequence website, create a dedicated portrait animation for mobile alongside the landscape desktop version.
 
 Generate portrait source images and connected animation clips in approximately 9:16. Recompose the scene for a tall screen rather than stretching landscape footage.


### PR DESCRIPTION
Users who already have fal.ai MCP connected currently encounter Higgsfield-only instructions, including during logo generation. This documentation-only change allows fal.ai when explicitly requested while keeping Higgsfield as the default.

The desktop prompt checks callable tools before selecting the alternative, and mobile refinement carries that selection forward. The README explains the option and the need to inspect model-specific controls. No automatic provider fallback, model-parity claims, dependencies, or changes to the referral link are introduced.

Validation: reviewed the three-file diff for consistent provider wording; `git diff --check` passes. No live fal.ai/Higgsfield generation was performed, so this draft proposes prompt behavior rather than claiming an end-to-end tested integration.
